### PR TITLE
Remove privacy compliance note from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ A live example of this blog generator can be found at [3960! Journal](http://jou
 * The Blogophon comes with a built-in image-scaler for responsive images.
 * The default theme puts all relevant meta stuff into `<head>` for SEO and social sharing (via schema.org and OpenGraph) as well as the [IndieWeb](https://indieweb.org/).
 * A ton of [special features](docs/special-features.md) like RSS/ATOM newsfeeds, Accelerated Mobile Pages (AMP), Progressive Web App (PWA), Facebook Instant Articles, sending Webmentions, Gopher-support etc.
-* As the Blogophon only consists of static pages, there is no personal data (cookies, etc.) aggregated by your blog - therefore it is easy to comply with any form of privacy protection law (like the [GDPR](https://en.wikipedia.org/wiki/General_Data_Protection_Regulation)).
 
 Requirements
 ------------


### PR DESCRIPTION
This is a document generator, not a telecommunication software.

My cup of tea should not be in compliance with regulations of a mobile postmarkeOS device.